### PR TITLE
check for some solver header files if their lib seems to be found

### DIFF
--- a/configure
+++ b/configure
@@ -18509,6 +18509,18 @@ $as_echo "#define OSI_HAS_CPLEX 1" >>confdefs.h
 
   fi
 
+if test "$coin_has_cplex" = yes ; then
+  coin_save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$cplex_cflags $CPPFLAGS"
+  ac_fn_cxx_check_header_mongrel "$LINENO" "cplex.h" "ac_cv_header_cplex_h" "$ac_includes_default"
+if test "x$ac_cv_header_cplex_h" = xyes; then :
+  CPPFLAGS="$coin_save_CPPFLAGS"
+else
+  as_fn_error $? "CPLEX library available, but CPLEX header cplex.h cannot be compiled. Consider using --without-cplex." "$LINENO" 5
+fi
+
+
+fi
 
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for package Mosek with function MSK_makeenv" >&5
@@ -18754,6 +18766,18 @@ $as_echo "#define OSI_HAS_MOSEK 1" >>confdefs.h
 
   fi
 
+if test "$coin_has_mosek" = yes ; then
+  coin_save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$mosek_cflags $CPPFLAGS"
+  ac_fn_cxx_check_header_mongrel "$LINENO" "mosek.h" "ac_cv_header_mosek_h" "$ac_includes_default"
+if test "x$ac_cv_header_mosek_h" = xyes; then :
+  CPPFLAGS="$coin_save_CPPFLAGS"
+else
+  as_fn_error $? "MOSEK library available, but MOSEK header mosek.h cannot be compiled. Consider using --without-mosek." "$LINENO" 5
+fi
+
+
+fi
 
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for package Xpress with function XPRSinit" >&5
@@ -18999,6 +19023,18 @@ $as_echo "#define OSI_HAS_XPRESS 1" >>confdefs.h
 
   fi
 
+if test "$coin_has_xpress" = yes ; then
+  coin_save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$xpress_cflags $CPPFLAGS"
+  ac_fn_cxx_check_header_mongrel "$LINENO" "xprs.h" "ac_cv_header_xprs_h" "$ac_includes_default"
+if test "x$ac_cv_header_xprs_h" = xyes; then :
+  CPPFLAGS="$coin_save_CPPFLAGS"
+else
+  as_fn_error $? "XPRESS library available, but XPRESS header xprs.h cannot be compiled. Consider using --without-xpress." "$LINENO" 5
+fi
+
+
+fi
 
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for package Gurobi with function GRBloadenv" >&5
@@ -19244,6 +19280,18 @@ $as_echo "#define OSI_HAS_GUROBI 1" >>confdefs.h
 
   fi
 
+if test "$coin_has_gurobi" = yes ; then
+  coin_save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$gurobi_cflags $CPPFLAGS"
+  ac_fn_cxx_check_header_mongrel "$LINENO" "gurobi_c.h" "ac_cv_header_gurobi_c_h" "$ac_includes_default"
+if test "x$ac_cv_header_gurobi_c_h" = xyes; then :
+  CPPFLAGS="$coin_save_CPPFLAGS"
+else
+  as_fn_error $? "Gurobi library available, but Gurobi header gurobi_c.h cannot be compiled. Consider using --without-gurobi." "$LINENO" 5
+fi
+
+
+fi
 
 
    if test "$BUILDTOOLS_DEBUG" = 1 ; then

--- a/configure.ac
+++ b/configure.ac
@@ -84,15 +84,43 @@ AC_COIN_CHK_PKG(SoPlex,[OsiSpxLib OsiTest],[coinsoplex < 1.7],[build])
 
 AC_COIN_CHK_LIB(Cplex,[OsiCpxLib OsiTest],[-lcplex -lpthread -lm -ldl],[],[],
                 [CPXgetstat])
+if test "$coin_has_cplex" = yes ; then
+  coin_save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$cplex_cflags $CPPFLAGS"
+  AC_CHECK_HEADER([cplex.h],
+    [CPPFLAGS="$coin_save_CPPFLAGS"],
+    [AC_MSG_ERROR([CPLEX library available, but CPLEX header cplex.h cannot be compiled. Consider using --without-cplex.])])
+fi
 
 AC_COIN_CHK_LIB(Mosek,[OsiMskLib OsiTest],[-lmosek64 -lpthread],[],[],
                 [MSK_makeenv])
+if test "$coin_has_mosek" = yes ; then
+  coin_save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$mosek_cflags $CPPFLAGS"
+  AC_CHECK_HEADER([mosek.h],
+    [CPPFLAGS="$coin_save_CPPFLAGS"],
+    [AC_MSG_ERROR([MOSEK library available, but MOSEK header mosek.h cannot be compiled. Consider using --without-mosek.])])
+fi
 
 AC_COIN_CHK_LIB(Xpress,[OsiXprLib OsiTest],[-lxprs -lxprl],[],[],
                 [XPRSinit])
+if test "$coin_has_xpress" = yes ; then
+  coin_save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$xpress_cflags $CPPFLAGS"
+  AC_CHECK_HEADER([xprs.h],
+    [CPPFLAGS="$coin_save_CPPFLAGS"],
+    [AC_MSG_ERROR([XPRESS library available, but XPRESS header xprs.h cannot be compiled. Consider using --without-xpress.])])
+fi
 
 AC_COIN_CHK_LIB(Gurobi,[OsiGrbLib OsiTest],[-lgurobi -lpthread -lm],[],[],
                 [GRBloadenv])
+if test "$coin_has_gurobi" = yes ; then
+  coin_save_CPPFLAGS="$CPPFLAGS"
+  CPPFLAGS="$gurobi_cflags $CPPFLAGS"
+  AC_CHECK_HEADER([gurobi_c.h],
+    [CPPFLAGS="$coin_save_CPPFLAGS"],
+    [AC_MSG_ERROR([Gurobi library available, but Gurobi header gurobi_c.h cannot be compiled. Consider using --without-gurobi.])])
+fi
 
 AC_COIN_FINALIZE_FLAGS([OsiGlpkLib OskSpxLib OsiCpxLib OsiMskLib OsiXprLib OsiGrbLib OsiTest])
 


### PR DESCRIPTION
With this change, if the default linker flags for cplex/mosek/xpress/gurobi work to resolve a solver symbol, but the default compiler flags don't work to find the solvers header, things stop with an error.
It might be nicer to integrate the check for the header into AC_COIN_CHK_LIB and then still proceed, but I'm afraid of touching AC_COIN_CHK_LIB and the macros it is using. There are already so many arguments.

Hmm, maybe there could be another macro, AC_COIN_CHK_LIB+HEADER, that just replicates the logic that is put into configure.ac here.
