### PR TITLE
Osi WriteLp only used row and col names if nameDiscipline was == 2, change to >= 1

### DIFF
--- a/src/Osi/OsiSolverInterface.cpp
+++ b/src/Osi/OsiSolverInterface.cpp
@@ -1364,7 +1364,7 @@ void OsiSolverInterface::writeLp(const char *filename,
   int nameDiscipline;
   if (!getIntParam(OsiNameDiscipline, nameDiscipline))
     nameDiscipline = 0;
-  if (useRowNames && nameDiscipline == 2) {
+  if (useRowNames && nameDiscipline >= 1) {
     colnames = new char *[getNumCols()];
     rownames = new char *[getNumRows() + 1];
     for (int i = 0; i < getNumCols(); ++i)
@@ -1382,7 +1382,7 @@ void OsiSolverInterface::writeLp(const char *filename,
     rownames, colnames, epsilon, numberAcross,
     decimals, objSense, useRowNames);
 
-  if (useRowNames && nameDiscipline == 2) {
+  if (useRowNames && nameDiscipline >= 1) {
     for (int i = 0; i < getNumCols(); ++i)
       free(colnames[i]);
     for (int i = 0; i < getNumRows() + 1; ++i)
@@ -1404,7 +1404,7 @@ void OsiSolverInterface::writeLp(FILE *fp,
   char **rownames;
   int nameDiscipline;
   getIntParam(OsiNameDiscipline, nameDiscipline);
-  if (useRowNames && nameDiscipline == 2) {
+  if (useRowNames && nameDiscipline >= 1) {
     colnames = new char *[getNumCols()];
     rownames = new char *[getNumRows() + 1];
     for (int i = 0; i < getNumCols(); ++i)
@@ -1422,7 +1422,7 @@ void OsiSolverInterface::writeLp(FILE *fp,
     rownames, colnames, epsilon, numberAcross,
     decimals, objSense, useRowNames);
 
-  if (useRowNames && nameDiscipline == 2) {
+  if (useRowNames && nameDiscipline >= 1) {
     for (int i = 0; i < getNumCols(); ++i)
       free(colnames[i]);
     for (int i = 0; i < getNumRows() + 1; ++i)


### PR DESCRIPTION
Osi WriteLp only used row and col names if nameDiscipline was == 2, This should be changed to >= 1 since both values 1 and 2 define to use names. See OsiNameDiscipline.