### PR TITLE
Set RuntimeLibrary (Multithreaded DLL, etc) setting for VS2019 to default for libOsi

### DIFF
--- a/MSVisualStudio/v16/libOsi/libOsi.vcxproj
+++ b/MSVisualStudio/v16/libOsi/libOsi.vcxproj
@@ -178,7 +178,6 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
     </ClCompile>
     <Link>

--- a/src/Osi/OsiSolverInterface.cpp
+++ b/src/Osi/OsiSolverInterface.cpp
@@ -1364,7 +1364,7 @@ void OsiSolverInterface::writeLp(const char *filename,
   int nameDiscipline;
   if (!getIntParam(OsiNameDiscipline, nameDiscipline))
     nameDiscipline = 0;
-  if (useRowNames && nameDiscipline == 2) {
+  if (useRowNames && nameDiscipline >= 1) {
     colnames = new char *[getNumCols()];
     rownames = new char *[getNumRows() + 1];
     for (int i = 0; i < getNumCols(); ++i)
@@ -1382,7 +1382,7 @@ void OsiSolverInterface::writeLp(const char *filename,
     rownames, colnames, epsilon, numberAcross,
     decimals, objSense, useRowNames);
 
-  if (useRowNames && nameDiscipline == 2) {
+  if (useRowNames && nameDiscipline >= 1) {
     for (int i = 0; i < getNumCols(); ++i)
       free(colnames[i]);
     for (int i = 0; i < getNumRows() + 1; ++i)
@@ -1404,7 +1404,7 @@ void OsiSolverInterface::writeLp(FILE *fp,
   char **rownames;
   int nameDiscipline;
   getIntParam(OsiNameDiscipline, nameDiscipline);
-  if (useRowNames && nameDiscipline == 2) {
+  if (useRowNames && nameDiscipline >= 1) {
     colnames = new char *[getNumCols()];
     rownames = new char *[getNumRows() + 1];
     for (int i = 0; i < getNumCols(); ++i)
@@ -1422,7 +1422,7 @@ void OsiSolverInterface::writeLp(FILE *fp,
     rownames, colnames, epsilon, numberAcross,
     decimals, objSense, useRowNames);
 
-  if (useRowNames && nameDiscipline == 2) {
+  if (useRowNames && nameDiscipline >= 1) {
     for (int i = 0; i < getNumCols(); ++i)
       free(colnames[i]);
     for (int i = 0; i < getNumRows() + 1; ++i)


### PR DESCRIPTION
For libOsi, this PR sets RuntimeLibrary (Multithreaded DLL, etc.--how to link in the Microsoft Run-Time library MSVCRT / LIBCMT) for VS2019 to default values for all configurations by removing explicit values.

All Debug configs were at defaults, but Release was not, leading to link errors when linking multiple libraries together. These conflicts are prevented if all simply use the default (Multithreaded DLL (Debug or Release)). This has nothing to do with the result of the Configuration Type (static lib, dll, exe, etc.), but only how the MS runtimes are linked.