### PR TITLE
Set RuntimeLibrary (Multithreaded DLL, etc) setting for VS2019 to default

### DIFF
--- a/MSVisualStudio/v16/libOsi/libOsi.vcxproj
+++ b/MSVisualStudio/v16/libOsi/libOsi.vcxproj
@@ -178,7 +178,6 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
     </ClCompile>
     <Link>


### PR DESCRIPTION
For libOsi project (similar to libCbc, libCbcSolver in PR coin-or/cbc#336 and libClp in PR coin-or/clp#161) this PR sets RuntimeLibrary (Multithreaded DLL, etc.--how to link in the Microsoft Run-Time library MSVCRT / LIBCMT) for VS2019 to default value for all configurations by removing explicit values.

All Debug configs were at defaults, but Release was not, leading to link errors when linking multiple libraries together. These conflicts are prevented if all simply use the default (Multithreaded DLL (Debug or Release)). This has nothing to do with the result of the Configuration Type (static lib, dll, exe, etc.), but only how the MS runtimes are linked.