### PR TITLE
Fix vs2019 libOsi by adding OsiFeatures.

### DIFF
--- a/MSVisualStudio/v16/libOsi/libOsi.vcxproj
+++ b/MSVisualStudio/v16/libOsi/libOsi.vcxproj
@@ -25,6 +25,7 @@
     <ClCompile Include="..\..\..\src\Osi\OsiColCut.cpp" />
     <ClCompile Include="..\..\..\src\Osi\OsiCut.cpp" />
     <ClCompile Include="..\..\..\src\Osi\OsiCuts.cpp" />
+    <ClCompile Include="..\..\..\src\Osi\OsiFeatures.cpp" />
     <ClCompile Include="..\..\..\src\Osi\OsiNames.cpp" />
     <ClCompile Include="..\..\..\src\Osi\OsiPresolve.cpp" />
     <ClCompile Include="..\..\..\src\Osi\OsiRowCut.cpp" />
@@ -41,6 +42,7 @@
     <ClInclude Include="..\..\..\src\Osi\OsiConfig.h" />
     <ClInclude Include="..\..\..\src\Osi\OsiCut.hpp" />
     <ClInclude Include="..\..\..\src\Osi\OsiCuts.hpp" />
+    <ClInclude Include="..\..\..\src\Osi\OsiFeatures.hpp" />
     <ClInclude Include="..\..\..\src\Osi\OsiPresolve.hpp" />
     <ClInclude Include="..\..\..\src\Osi\OsiRowCut.hpp" />
     <ClInclude Include="..\..\..\src\Osi\OsiRowCutDebugger.hpp" />

--- a/src/Osi/OsiFeatures.cpp
+++ b/src/Osi/OsiFeatures.cpp
@@ -1,4 +1,4 @@
-#include <OsiSolverInterface.hpp>
+#include "OsiSolverInterface.hpp"
 #include <limits>
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
The OsiFeatures.cpp was missing from vs2019 libOsi.