### PR TITLE
Deduplicate 'hashCut' and 'same'

### DIFF
--- a/src/Osi/OsiRowCut.hpp
+++ b/src/Osi/OsiRowCut.hpp
@@ -206,6 +206,10 @@ private:
   //@}
 };
 
+int hashCut(const OsiRowCut & x, int size);
+
+bool same(const OsiRowCut &x, const OsiRowCut &y);
+
 #ifdef OSI_INLINE_ROWCUT_METHODS
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
Several copies of these functions are hidden inside Cgl and Cbc, see related PRs.