### PR TITLE
remove use of std::bind2nd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+21/03/2023
+  - remove use of std::bind2nd to improve compatibility with C++17, see #177
+
 11/01/2023
   - use new XPRSgetmipentities() function from XPRESS 41
 

--- a/src/OsiCommonTest/OsiSolverInterfaceTest.cpp
+++ b/src/OsiCommonTest/OsiSolverInterfaceTest.cpp
@@ -1321,8 +1321,8 @@ bool test16SebastianNowozin(OsiSolverInterface *si)
   int rows_to_delete_arr[] = { 0 };
   si->deleteRows(1, rows_to_delete_arr);
 
-  std::transform(objective, objective + 4, objective,
-    std::bind2nd(std::plus< double >(), 0.15));
+  for (int i = 0; i < 4; ++i )
+    objective[i] += 0.15;
   si->setObjective(objective);
   si->resolve();
   OSIUNITTEST_ASSERT_ERROR(si->isProvenOptimal(), return false, *si, "test16SebastianNowozin second resolve");

--- a/test/OsiTestSolverInterface.cpp
+++ b/test/OsiTestSolverInterface.cpp
@@ -464,8 +464,8 @@ OsiTestSolverInterface::resolve()
   // Set the dual starting point
   VOL_dvector& dsol = volprob_.dsol;
   dsol.allocate(dsize);
-  std::transform(rowprice_, rowprice_+dsize, dsol.v,
-		 std::bind2nd(std::multiplies<double>(), objsense_));
+  for (i = 0; i < dsize; ++i)
+    dsol.v[i] = rowprice_[i] * objsense_;
 
   // adjust the dual vector (if necessary) to be sure it's feasible
   double * dv = dsol.v;


### PR DESCRIPTION
Easy changes to add compatibility with C++17.

Closes #176.