### PR TITLE
Linux and windows ci updates for build warnings

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,32 +18,32 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         build_static: [true, false]
         flags: [ADD_CXXFLAGS=-fvisibility=hidden]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev]
         include:
-          - os: macos-10.15
+          - os: macos-12
             build_static: false
-            flags: CC=clang OSX=10.15
+            flags: CC=clang OSX=12
             download_requirements: brew install metis bash
-          - os: macos-10.15
+          - os: macos-12
             build_static: false
-            flags: CC=gcc-9 CXX=g++-9 OSX=10.15
+            flags: CC=gcc-11 CXX=g++-11 OSX=12
             download_requirements: brew install metis bash
-          - os: macos-10.15
+          - os: macos-12
             build_static: false
-            flags: CC=gcc-10 CXX=g++-10 OSX=10.15
+            flags: CC=gcc-12 CXX=g++-12 OSX=12
             download_requirements: brew install metis bash
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ github.event.repository.name }}
       - name: Install required packages from package manager
         run: ${{ matrix.download_requirements }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -70,7 +70,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
           tar -czvf release.tar.gz -C dist .
       - name: Checkout package name generation script
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: coin-or-tools/platform-analysis-tools
           path: tools
@@ -85,7 +85,7 @@ jobs:
           echo "platform_string=${platform_str}" >> $GITHUB_ENV
       - name: Upload Artifact
         if: ${{ github.event_name == 'pull_request'}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}-${{ github.head_ref }}-${{ env.platform_string }}.tar.gz
           path: release.tar.gz

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -30,11 +30,11 @@ jobs:
         ]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ github.event.repository.name }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -65,12 +65,22 @@ jobs:
           ADD_ARGS=()
           ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )
           ./coinbrew/coinbrew fetch ${{ github.event.repository.name }} --skip-update "${ADD_ARGS[@]}"
+          echo "##################################################"
+          echo "### Extracting Netlib and Miplib3 if available"
+          if [ -d "./Data/Netlib/" ]; then gunzip ./Data/Netlib/*.gz; fi
+          if [ -d "./Data/Miplib3/" ]; then gunzip ./Data/Miplib3/*.gz; fi
+          echo "##################################################"       
         shell: msys2 {0}
       - name: Build project for msvs
         if: ${{ matrix.arch == 'msvs' }}
         shell: cmd
         run: |
           msbuild ${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}.sln /p:Configuration=Release /p:Platform=x64 /m
+      - name: Test project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          .\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}Test.cmd .\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release .\Data\Sample .\Data\Netlib .\Data\Miplib3
       - name: Install project for msvs
         if: ${{ matrix.arch == 'msvs' }}
         shell: cmd
@@ -105,7 +115,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
         shell: msys2 {0}
       - name: Upload failed build directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: ${{ matrix.os}}-{{ matrix.arch }}-debug=${{ matrix.debug }}-failedbuild
@@ -123,7 +133,7 @@ jobs:
         if: ${{ matrix.arch != 'msvc' }}
       - name: Upload artifact
         if: ${{ github.event_name == 'pull_request'}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ github.event.repository.name }}-${{ github.head_ref }}-${{ env.package_suffix }}
           path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+﻿# Ignore files created during unit tests
+/MSVisualStudio/*/*.mps
+/MSVisualStudio/*/*.lp
+/MSVisualStudio/*/*.out

--- a/MSVisualStudio/v17/Osi.sln
+++ b/MSVisualStudio/v17/Osi.sln
@@ -26,6 +26,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		..\..\.github\workflows\windows-ci.yml = ..\..\.github\workflows\windows-ci.yml
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{19F0A284-FF77-4B8D-BEF9-31775B580170}"
+	ProjectSection(SolutionItems) = preProject
+		OsiTest.cmd = OsiTest.cmd
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -71,7 +76,9 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{FCF90EF8-93AE-482A-9B55-018B8338B99D} = {19F0A284-FF77-4B8D-BEF9-31775B580170}
 		{A0209C59-3B68-4EB6-8AB2-B16831D6C759} = {F8AFDCAA-7845-4221-8F63-45BE825B678A}
+		{19F0A284-FF77-4B8D-BEF9-31775B580170} = {F8AFDCAA-7845-4221-8F63-45BE825B678A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8D3882F5-D354-4362-9A7F-A5393F116053}

--- a/MSVisualStudio/v17/OsiTest.cmd
+++ b/MSVisualStudio/v17/OsiTest.cmd
@@ -1,0 +1,45 @@
+@REM This file will run command line tests, comparable to test\makefile.am
+
+@echo off
+SET "BINDIR=%~1"
+SET "SAMPLEDIR=%~2"
+SET "NETLIBDIR=%~3"
+SET "MIPLIBDIR=%~4"
+
+echo INFO: Running %0 %*
+echo INFO: Using bindir '%BINDIR%' and sampledir '%SAMPLEDIR%' and netlibdir '%NETLIBDIR%'
+echo INFO: Miplibdir '%MIPLIBDIR%' is ignored for these tests.
+
+if "%BINDIR%"=="" echo ERROR: No bindir given. && goto :usage
+if not exist "%BINDIR%" echo ERROR: Folder bindir %BINDIR% does not exist. && goto :usage
+
+if "%SAMPLEDIR%"=="" echo ERROR: No sampledir given. && goto :usage
+if not exist %SAMPLEDIR% echo ERROR: Folder sampledir %SAMPLEDIR% does not exist. && goto :usage
+if not %errorlevel%==0 echo ERROR: %SAMPLEDIR% cannot contain spaces. && goto :usage
+
+if "%NETLIBDIR%"=="" echo ERROR: No netlibdir given. && goto :usage
+if not exist %NETLIBDIR% echo ERROR: Folder netlibdir %NETLIBDIR% does not exist. && goto :usage
+if not %errorlevel%==0 echo ERROR: %NETLIBDIR% cannot contain spaces. && goto :usage
+
+goto :test
+
+:usage
+echo INFO: Usage %0 ^<bindir^> ^<sampledir^> ^<netlibdir^>
+echo INFO: where ^<bindir^> contains the executables, sampledir the sample files and netlibdir the netlib files.
+echo INFO: This script runs automated test.
+echo INFO: The ^<sampledir^> and ^<netlibdir^> must not contain spaces!
+echo INFO: For example: %0 "D:\Some Directory\" ..\..\samples\ "..\..\netlib"
+goto :error
+
+:error
+echo ERROR: An error occurred while running the tests!
+echo INFO: Finished Tests but failed
+exit /b 1
+
+:test
+echo INFO: Starting Tests
+
+"%BINDIR%\osiUnitTest.exe" -mpsDir=%SAMPLEDIR% -netlibDir=%NETLIBDIR% -testOsiSolverInterface 
+if not %errorlevel%==0 echo ERROR: Error running osiUnitTest.exe tests. && goto :error
+
+echo INFO: Finished Tests successfully (%ERRORLEVEL%)

--- a/MSVisualStudio/v17/OsiUnitTest/OsiUnitTest.vcxproj
+++ b/MSVisualStudio/v17/OsiUnitTest/OsiUnitTest.vcxproj
@@ -147,17 +147,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
-      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\..\..\..\Osi\MSVisualStudio\v17\libOsi\libOsi.vcxproj">
-      <Project>{bf5c7532-ee0a-479b-9993-72134087d530}</Project>
-    </ProjectReference>
-    <ProjectReference Include="..\libOsiCommonTest\libOsiCommonTest.vcxproj">
-      <Project>{109d6e6f-6d91-460f-86ae-df27400e09a9}</Project>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <ClCompile Include="..\..\..\test\OsiTestSolver.cpp" />
     <ClCompile Include="..\..\..\test\OsiTestSolverInterface.cpp" />
     <ClCompile Include="..\..\..\test\OsiTestSolverInterfaceIO.cpp" />
@@ -167,6 +156,17 @@
   <ItemGroup>
     <ClInclude Include="..\..\..\test\OsiTestSolver.hpp" />
     <ClInclude Include="..\..\..\test\OsiTestSolverInterface.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libOsiCommonTest\libOsiCommonTest.vcxproj">
+      <Project>{109d6e6f-6d91-460f-86ae-df27400e09a9}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libOsi\libOsi.vcxproj">
+      <Project>{bf5c7532-ee0a-479b-9993-72134087d530}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/MSVisualStudio/v17/libOsiCommonTest/libOsiCommonTest.vcxproj
+++ b/MSVisualStudio/v17/libOsiCommonTest/libOsiCommonTest.vcxproj
@@ -152,12 +152,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
-      <Project>{6D2EF92A-D693-47E3-A325-A686E78C5FFD}</Project>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
     </ProjectReference>
     <ProjectReference Include="..\libOsi\libOsi.vcxproj">
-      <Project>{BF5C7532-EE0A-479B-9993-72134087D530}</Project>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <Project>{bf5c7532-ee0a-479b-9993-72134087d530}</Project>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
For Linux-ci move to ubuntu 22.04 from 18.04 and macos-12 from 10.15. For Windows-ci add running tests.