### PR TITLE
Use return() instead of exit()

### DIFF
--- a/src/Osi/OsiSolverInterface.cpp
+++ b/src/Osi/OsiSolverInterface.cpp
@@ -1450,7 +1450,7 @@ int OsiSolverInterface::writeLpNative(const char *filename,
   if (!fp) {
     printf("### ERROR: in OsiSolverInterface::writeLpNative(): unable to open file %s\n",
       filename);
-    exit(1);
+    return (1);
   }
   int nerr = writeLpNative(fp, rowNames, columnNames,
     epsilon, numberAcross, decimals,


### PR DESCRIPTION
Previously, the function employed `exit()`, which, when invoked, results in the immediate termination of the entire program. In a library this is not a wanted response when handling errors, a better approach is to return an error code and let  the calling application handle the error.