### PR TITLE
Replace Coin{Max,Min} by std::{max,min}

### DIFF
--- a/examples/opbdp_solve.cpp
+++ b/examples/opbdp_solve.cpp
@@ -123,7 +123,7 @@ static int solve(const OsiSolverInterface * model,PBCS & pbcs, OrdInt & sol)
   // objective not too important
   double maximumObjElement = 0.0 ;
   for (i = 0 ; i < numberColumns ; i++) 
-    maximumObjElement = CoinMax(maximumObjElement,fabs(objective[i])) ;
+    maximumObjElement = std::max(maximumObjElement,fabs(objective[i])) ;
   int objGood = 0 ;
   double objMultiplier = 2520.0 ;
   bool good=true;
@@ -162,11 +162,11 @@ static int solve(const OsiSolverInterface * model,PBCS & pbcs, OrdInt & sol)
   // now real stuff
   for (i=0;i<numberRows;i++) {
     if (rowLower[i]!=-infinity)
-      maximumElement = CoinMax(maximumElement,fabs(rowLower[i])) ;
+      maximumElement = std::max(maximumElement,fabs(rowLower[i])) ;
     if (rowUpper[i]!=infinity)
-      maximumElement = CoinMax(maximumElement,fabs(rowUpper[i])) ;
+      maximumElement = std::max(maximumElement,fabs(rowUpper[i])) ;
     for (CoinBigIndex j=rowStart[i];j<rowStart[i]+rowLength[i];j++) 
-      maximumElement = CoinMax(maximumElement,fabs(elementByRow[j])) ;
+      maximumElement = std::max(maximumElement,fabs(elementByRow[j])) ;
   }
   assert (maximumElement);
   int elGood = 0 ;

--- a/src/Osi/OsiAuxInfo.cpp
+++ b/src/Osi/OsiAuxInfo.cpp
@@ -125,7 +125,7 @@ int OsiBabSolver::solution(double &solutionValue,
   //       this,bestSolution_,bestObjectiveValue_);
   if (bestObjectiveValue_ < solutionValue && bestSolution_) {
     // new solution
-    memcpy(betterSolution, bestSolution_, CoinMin(numberColumns, sizeSolution_) * sizeof(double));
+    memcpy(betterSolution, bestSolution_, std::min(numberColumns, sizeSolution_) * sizeof(double));
     if (sizeSolution_ < numberColumns)
       CoinZeroN(betterSolution + sizeSolution_, numberColumns - sizeSolution_);
     solutionValue = bestObjectiveValue_;
@@ -156,10 +156,10 @@ void OsiBabSolver::setSolution(const double *solution, int numberColumns, double
   assert(solver_);
   // just in case size has changed
   delete[] bestSolution_;
-  sizeSolution_ = CoinMin(solver_->getNumCols(), numberColumns);
+  sizeSolution_ = std::min(solver_->getNumCols(), numberColumns);
   bestSolution_ = new double[sizeSolution_];
   CoinZeroN(bestSolution_, sizeSolution_);
-  CoinMemcpyN(solution, CoinMin(sizeSolution_, numberColumns), bestSolution_);
+  CoinMemcpyN(solution, std::min(sizeSolution_, numberColumns), bestSolution_);
   bestObjectiveValue_ = objectiveValue * solver_->getObjSense();
 }
 // Get objective  (well mip bound)

--- a/src/Osi/OsiBranchingObject.cpp
+++ b/src/Osi/OsiBranchingObject.cpp
@@ -503,8 +503,8 @@ double
 OsiSimpleInteger::infeasibility(const OsiBranchingInformation *info, int &whichWay) const
 {
   double value = info->solution_[columnNumber_];
-  value = CoinMax(value, info->lower_[columnNumber_]);
-  value = CoinMin(value, info->upper_[columnNumber_]);
+  value = std::max(value, info->lower_[columnNumber_]);
+  value = std::min(value, info->upper_[columnNumber_]);
   double nearest = floor(value + (1.0 - 0.5));
   if (nearest > value) {
     whichWay = 1;
@@ -558,21 +558,21 @@ OsiSimpleInteger::infeasibility(const OsiBranchingInformation *info, int &whichW
       // if up makes infeasible then make at least default
       double newUp = activity[iRow] + upMovement * el2;
       if (newUp > upper[iRow] + tolerance || newUp < lower[iRow] - tolerance)
-        u = CoinMax(u, info->defaultDual_);
+        u = std::max(u, info->defaultDual_);
       upEstimate += u * upMovement;
       // if down makes infeasible then make at least default
       double newDown = activity[iRow] - downMovement * el2;
       if (newDown > upper[iRow] + tolerance || newDown < lower[iRow] - tolerance)
-        d = CoinMax(d, info->defaultDual_);
+        d = std::max(d, info->defaultDual_);
       downEstimate += d * downMovement;
     }
     if (downEstimate >= upEstimate) {
-      infeasibility_ = CoinMax(1.0e-12, upEstimate);
-      otherInfeasibility_ = CoinMax(1.0e-12, downEstimate);
+      infeasibility_ = std::max(1.0e-12, upEstimate);
+      otherInfeasibility_ = std::max(1.0e-12, downEstimate);
       whichWay = 1;
     } else {
-      infeasibility_ = CoinMax(1.0e-12, downEstimate);
-      otherInfeasibility_ = CoinMax(1.0e-12, upEstimate);
+      infeasibility_ = std::max(1.0e-12, downEstimate);
+      otherInfeasibility_ = std::max(1.0e-12, upEstimate);
       whichWay = 0;
     }
     returnValue = infeasibility_;
@@ -593,8 +593,8 @@ OsiSimpleInteger::feasibleRegion(OsiSolverInterface *solver,
   const OsiBranchingInformation *info) const
 {
   double value = info->solution_[columnNumber_];
-  double newValue = CoinMax(value, info->lower_[columnNumber_]);
-  newValue = CoinMin(newValue, info->upper_[columnNumber_]);
+  double newValue = std::max(value, info->lower_[columnNumber_]);
+  newValue = std::min(newValue, info->upper_[columnNumber_]);
   newValue = floor(newValue + 0.5);
   solver->setColLower(columnNumber_, newValue);
   solver->setColUpper(columnNumber_, newValue);
@@ -613,8 +613,8 @@ OsiBranchingObject *
 OsiSimpleInteger::createBranch(OsiSolverInterface *solver, const OsiBranchingInformation *info, int way) const
 {
   double value = info->solution_[columnNumber_];
-  value = CoinMax(value, info->lower_[columnNumber_]);
-  value = CoinMin(value, info->upper_[columnNumber_]);
+  value = std::max(value, info->lower_[columnNumber_]);
+  value = std::min(value, info->upper_[columnNumber_]);
   assert(info->upper_[columnNumber_] > info->lower_[columnNumber_]);
 #ifndef NDEBUG
   double nearest = floor(value + 0.5);
@@ -853,7 +853,7 @@ OsiSOS::OsiSOS(const OsiSolverInterface *, int numberMembers,
     double last = -COIN_DBL_MAX;
     int i;
     for (i = 0; i < numberMembers_; i++) {
-      double possible = CoinMax(last + 1.0e-10, weights_[i]);
+      double possible = std::max(last + 1.0e-10, weights_[i]);
       weights_[i] = possible;
       last = possible;
     }
@@ -946,7 +946,7 @@ OsiSOS::infeasibility(const OsiBranchingInformation *info, int &whichWay) const
       throw CoinError("Weights too close together in SOS", "infeasibility", "OsiSOS");
     lastWeight = weights_[j];
     if (upper[iColumn]) {
-      double value = CoinMax(0.0, solution[iColumn]);
+      double value = std::max(0.0, solution[iColumn]);
       if (value > integerTolerance) {
         // Possibly due to scaling a fixed variable might slip through
 #ifdef COIN_DEVELOP
@@ -1111,7 +1111,7 @@ OsiSOS::infeasibility(const OsiBranchingInformation *info, int &whichWay) const
           // if makes infeasible then make at least default
           double newValue = activity[iRow] + movement;
           if (newValue > upper[iRow] + primalTolerance || newValue < lower[iRow] - primalTolerance)
-            thisEstimate = CoinMax(thisEstimate, info->defaultDual_);
+            thisEstimate = std::max(thisEstimate, info->defaultDual_);
           estimate += thisEstimate;
         }
         for (j = 0; j < n2; j++) {
@@ -1131,7 +1131,7 @@ OsiSOS::infeasibility(const OsiBranchingInformation *info, int &whichWay) const
             // if makes infeasible then make at least default
             double newValue = activity[iRow] + movement;
             if (newValue > upper[iRow] + primalTolerance || newValue < lower[iRow] - primalTolerance)
-              thisEstimate = CoinMax(thisEstimate, info->defaultDual_);
+              thisEstimate = std::max(thisEstimate, info->defaultDual_);
             estimate += thisEstimate;
           }
         }
@@ -1141,12 +1141,12 @@ OsiSOS::infeasibility(const OsiBranchingInformation *info, int &whichWay) const
       double downEstimate = fakeSolution[0];
       double upEstimate = fakeSolution[1];
       if (downEstimate >= upEstimate) {
-        infeasibility_ = CoinMax(1.0e-12, upEstimate);
-        otherInfeasibility_ = CoinMax(1.0e-12, downEstimate);
+        infeasibility_ = std::max(1.0e-12, upEstimate);
+        otherInfeasibility_ = std::max(1.0e-12, downEstimate);
         whichWay = 1;
       } else {
-        infeasibility_ = CoinMax(1.0e-12, downEstimate);
-        otherInfeasibility_ = CoinMax(1.0e-12, upEstimate);
+        infeasibility_ = std::max(1.0e-12, downEstimate);
+        otherInfeasibility_ = std::max(1.0e-12, upEstimate);
         whichWay = 0;
       }
       whichWay_ = static_cast< short >(whichWay);
@@ -1176,7 +1176,7 @@ OsiSOS::feasibleRegion(OsiSolverInterface *solver, const OsiBranchingInformation
   if (sosType_ == 1) {
     for (j = 0; j < numberMembers_; j++) {
       int iColumn = members_[j];
-      double value = CoinMax(0.0, solution[iColumn]);
+      double value = std::max(0.0, solution[iColumn]);
       if (value > sum && upper[iColumn]) {
         firstNonZero = j;
         sum = value;
@@ -1188,8 +1188,8 @@ OsiSOS::feasibleRegion(OsiSolverInterface *solver, const OsiBranchingInformation
     for (j = 1; j < numberMembers_; j++) {
       int iColumn = members_[j];
       int jColumn = members_[j - 1];
-      double value1 = CoinMax(0.0, solution[iColumn]);
-      double value0 = CoinMax(0.0, solution[jColumn]);
+      double value1 = std::max(0.0, solution[iColumn]);
+      double value0 = std::max(0.0, solution[jColumn]);
       double value = value0 + value1;
       if (value > sum) {
         if (upper[iColumn] || upper[jColumn]) {
@@ -1203,7 +1203,7 @@ OsiSOS::feasibleRegion(OsiSolverInterface *solver, const OsiBranchingInformation
   for (j = 0; j < numberMembers_; j++) {
     if (j < firstNonZero || j > lastNonZero) {
       int iColumn = members_[j];
-      double value = CoinMax(0.0, solution[iColumn]);
+      double value = std::max(0.0, solution[iColumn]);
       movement += value;
       solver->setColUpper(iColumn, 0.0);
     }
@@ -1267,7 +1267,7 @@ OsiSOS::createBranch(OsiSolverInterface *solver, const OsiBranchingInformation *
   for (j = 0; j < numberMembers_; j++) {
     int iColumn = members_[j];
     if (upper[iColumn]) {
-      double value = CoinMax(0.0, solution[iColumn]);
+      double value = std::max(0.0, solution[iColumn]);
       sum += value;
       if (firstNonFixed < 0)
         firstNonFixed = j;
@@ -1396,8 +1396,8 @@ void OsiSOSBranchingObject::print(const OsiSolverInterface *solver)
   for (i = 0; i < numberMembers; i++) {
     double bound = upper[which[i]];
     if (bound) {
-      first = CoinMin(first, i);
-      last = CoinMax(last, i);
+      first = std::min(first, i);
+      last = std::max(last, i);
     }
   }
   // *** for way - up means fix all those in down section
@@ -1486,7 +1486,7 @@ OsiLotsize::OsiLotsize(const OsiSolverInterface *,
     // and for safety
     bound_[numberRanges_] = bound_[numberRanges_ - 1];
     for (i = 1; i < numberRanges_; i++) {
-      largestGap_ = CoinMax(largestGap_, bound_[i] - bound_[i - 1]);
+      largestGap_ = std::max(largestGap_, bound_[i] - bound_[i - 1]);
     }
   } else {
     bound_ = new double[2 * numberPoints + 2];
@@ -1505,7 +1505,7 @@ OsiLotsize::OsiLotsize(const OsiSolverInterface *,
         hi = thisHi;
       } else {
         //overlap
-        hi = CoinMax(hi, thisHi);
+        hi = std::max(hi, thisHi);
         bound_[2 * numberRanges_ - 1] = hi;
       }
     }
@@ -1513,7 +1513,7 @@ OsiLotsize::OsiLotsize(const OsiSolverInterface *,
     bound_[2 * numberRanges_] = bound_[2 * numberRanges_ - 2];
     bound_[2 * numberRanges_ + 1] = bound_[2 * numberRanges_ - 1];
     for (i = 1; i < numberRanges_; i++) {
-      largestGap_ = CoinMax(largestGap_, bound_[2 * i] - bound_[2 * i - 1]);
+      largestGap_ = std::max(largestGap_, bound_[2 * i] - bound_[2 * i - 1]);
     }
   }
   delete[] sort;
@@ -1719,8 +1719,8 @@ OsiLotsize::infeasibility(const OsiBranchingInformation *info, int &preferredWay
   const double *lower = info->lower_;
   const double *upper = info->upper_;
   double value = solution[columnNumber_];
-  value = CoinMax(value, lower[columnNumber_]);
-  value = CoinMin(value, upper[columnNumber_]);
+  value = std::max(value, lower[columnNumber_]);
+  value = std::min(value, upper[columnNumber_]);
   double integerTolerance = info->integerTolerance_;
   /*printf("%d %g %g %g %g\n",columnNumber_,value,lower[columnNumber_],
     solution[columnNumber_],upper[columnNumber_]);*/
@@ -1783,8 +1783,8 @@ OsiLotsize::feasibleRegion(OsiSolverInterface *solver, const OsiBranchingInforma
   const double *upper = solver->getColUpper();
   const double *solution = info->solution_;
   double value = solution[columnNumber_];
-  value = CoinMax(value, lower[columnNumber_]);
-  value = CoinMin(value, upper[columnNumber_]);
+  value = std::max(value, lower[columnNumber_]);
+  value = std::min(value, upper[columnNumber_]);
   findRange(value, info->integerTolerance_);
   double nearest;
   if (rangeType_ == 1) {
@@ -1819,8 +1819,8 @@ OsiLotsize::createBranch(OsiSolverInterface *solver, const OsiBranchingInformati
   const double *lower = solver->getColLower();
   const double *upper = solver->getColUpper();
   double value = solution[columnNumber_];
-  value = CoinMax(value, lower[columnNumber_]);
-  value = CoinMin(value, upper[columnNumber_]);
+  value = std::max(value, lower[columnNumber_]);
+  value = std::min(value, upper[columnNumber_]);
   assert(!findRange(value, info->integerTolerance_));
   return new OsiLotsizeBranchingObject(solver, this, way,
     value);

--- a/src/Osi/OsiBranchingObject.hpp
+++ b/src/Osi/OsiBranchingObject.hpp
@@ -492,7 +492,7 @@ public:
   const int *columnLength_;
   /// Row indices
   const int *row_;
-  /** Useful region of length CoinMax(numberColumns,2*numberRows)
+  /** Useful region of length std::max(numberColumns,2*numberRows)
       This is allocated and deleted before OsiObject::infeasibility
       It is zeroed on entry and should be so on exit
       It only exists if defaultDual_>=0.0

--- a/src/Osi/OsiChooseVariable.cpp
+++ b/src/Osi/OsiChooseVariable.cpp
@@ -192,7 +192,7 @@ int OsiChooseVariable::setupList(OsiBranchingInformation *info, bool initialize)
   int checkIndex = 0;
   int bestPriority = COIN_INT_MAX;
   // pretend one strong even if none
-  int maximumStrong = numberStrong_ ? CoinMin(numberStrong_, numberObjects) : 1;
+  int maximumStrong = numberStrong_ ? std::min(numberStrong_, numberObjects) : 1;
   int putOther = numberObjects;
   int i;
   for (i = 0; i < maximumStrong; i++) {
@@ -683,7 +683,7 @@ int OsiChooseStrong::setupList(OsiBranchingInformation *info, bool initialize)
   double check = -COIN_DBL_MAX;
   int checkIndex = 0;
   int bestPriority = COIN_INT_MAX;
-  int maximumStrong = CoinMin(numberStrong_, numberObjects);
+  int maximumStrong = std::min(numberStrong_, numberObjects);
   int putOther = numberObjects;
   int i;
   for (i = 0; i < numberObjects; i++) {
@@ -711,7 +711,7 @@ int OsiChooseStrong::setupList(OsiBranchingInformation *info, bool initialize)
       sumPi *= 0.01;
       info->defaultDual_ = sumPi; // switch on
       int numberColumns = solver_->getNumCols();
-      int size = CoinMax(numberColumns, 2 * numberRows);
+      int size = std::max(numberColumns, 2 * numberRows);
       info->usefulRegion_ = new double[size];
       CoinZeroN(info->usefulRegion_, size);
       info->indexRegion_ = new int[size];
@@ -767,7 +767,7 @@ int OsiChooseStrong::setupList(OsiBranchingInformation *info, bool initialize)
             list_[--putOther] = iObject;
           }
         }
-        maximumStrong = CoinMin(maximumStrong, putOther);
+        maximumStrong = std::min(maximumStrong, putOther);
         bestPriority = priorityLevel;
         check = -COIN_DBL_MAX;
         checkIndex = 0;
@@ -790,7 +790,7 @@ int OsiChooseStrong::setupList(OsiBranchingInformation *info, bool initialize)
         } else {
           // use shadow prices always
         }
-        value = MAXMIN_CRITERION * CoinMin(upEstimate, downEstimate) + (1.0 - MAXMIN_CRITERION) * CoinMax(upEstimate, downEstimate);
+        value = MAXMIN_CRITERION * std::min(upEstimate, downEstimate) + (1.0 - MAXMIN_CRITERION) * std::max(upEstimate, downEstimate);
         if (value > check) {
           //add to list
           int iObject = list_[checkIndex];
@@ -803,7 +803,7 @@ int OsiChooseStrong::setupList(OsiBranchingInformation *info, bool initialize)
           useful_[checkIndex] = value;
           // find worst
           check = COIN_DBL_MAX;
-          maximumStrong = CoinMin(maximumStrong, putOther);
+          maximumStrong = std::min(maximumStrong, putOther);
           for (int j = 0; j < maximumStrong; j++) {
             if (list_[j] >= 0) {
               if (useful_[j] < check) {
@@ -820,14 +820,14 @@ int OsiChooseStrong::setupList(OsiBranchingInformation *info, bool initialize)
           // to end
           assert(list_[putOther - 1] < 0);
           list_[--putOther] = i;
-          maximumStrong = CoinMin(maximumStrong, putOther);
+          maximumStrong = std::min(maximumStrong, putOther);
         }
       } else {
         // worse priority
         // to end
         assert(list_[putOther - 1] < 0);
         list_[--putOther] = i;
-        maximumStrong = CoinMin(maximumStrong, putOther);
+        maximumStrong = std::min(maximumStrong, putOther);
       }
     }
   }
@@ -838,7 +838,7 @@ int OsiChooseStrong::setupList(OsiBranchingInformation *info, bool initialize)
   // Get list
   numberOnList_ = 0;
   if (feasible) {
-    for (i = 0; i < CoinMin(maximumStrong, putOther); i++) {
+    for (i = 0; i < std::min(maximumStrong, putOther); i++) {
       if (list_[i] >= 0) {
         list_[numberOnList_] = list_[i];
         useful_[numberOnList_++] = -useful_[i];
@@ -899,7 +899,7 @@ int OsiChooseStrong::chooseVariable(OsiSolverInterface *solver, OsiBranchingInfo
       pseudoCosts_.setNumberBeforeTrusted(numberBeforeTrusted);
     }
 
-    int numberLeft = CoinMin(numberStrong_ - numberStrongDone_, numberUnsatisfied_);
+    int numberLeft = std::min(numberStrong_ - numberStrongDone_, numberUnsatisfied_);
     int numberToDo = 0;
     resetResults(numberLeft);
     int returnCode = 0;
@@ -917,7 +917,7 @@ int OsiChooseStrong::chooseVariable(OsiSolverInterface *solver, OsiBranchingInfo
         const OsiObject *obj = solver->object(iObject);
         double upEstimate = (upTotalChange[iObject] * obj->upEstimate()) / upNumber[iObject];
         double downEstimate = (downTotalChange[iObject] * obj->downEstimate()) / downNumber[iObject];
-        double value = MAXMIN_CRITERION * CoinMin(upEstimate, downEstimate) + (1.0 - MAXMIN_CRITERION) * CoinMax(upEstimate, downEstimate);
+        double value = MAXMIN_CRITERION * std::min(upEstimate, downEstimate) + (1.0 - MAXMIN_CRITERION) * std::max(upEstimate, downEstimate);
         if (value > bestTrusted) {
           bestObjectIndex_ = iObject;
           bestWhichWay_ = upEstimate > downEstimate ? 0 : 1;
@@ -980,7 +980,7 @@ int OsiChooseStrong::chooseVariable(OsiSolverInterface *solver, OsiBranchingInfo
               delete branch;
             }
           }
-          double value = MAXMIN_CRITERION * CoinMin(upEstimate, downEstimate) + (1.0 - MAXMIN_CRITERION) * CoinMax(upEstimate, downEstimate);
+          double value = MAXMIN_CRITERION * std::min(upEstimate, downEstimate) + (1.0 - MAXMIN_CRITERION) * std::max(upEstimate, downEstimate);
           if (value > bestTrusted) {
             bestTrusted = value;
             bestObjectIndex_ = iObject;
@@ -1186,7 +1186,7 @@ int OsiHotInfo::updateInformation(const OsiSolverInterface *solver, const OsiBra
     status = 1; // infeasible
   // Could do something different if we can't trust
   double newObjectiveValue = solver->getObjSense() * solver->getObjValue();
-  changes_[iBranch] = CoinMax(0.0, newObjectiveValue - originalObjectiveValue_);
+  changes_[iBranch] = std::max(0.0, newObjectiveValue - originalObjectiveValue_);
   // we might have got here by primal
   if (choose->trustStrongForBound()) {
     if (!status && newObjectiveValue >= info->cutoff_) {

--- a/src/Osi/OsiCuts.cpp
+++ b/src/Osi/OsiCuts.cpp
@@ -521,8 +521,8 @@ bool OsiCuts::insertIfNotDuplicateAndClean(OsiRowCut &rc,
 	double smallest = 1.0e100;
 	for (int i=0;i<numberElements;i++) {
 	  double value = fabs(newElements[i]);
-	  largest = CoinMax(largest,value);
-	  smallest = CoinMin(smallest,value);
+	  largest = std::max(largest,value);
+	  smallest = std::min(smallest,value);
 	}
 	if (largest>smallest*1.0e8||rhs>smallest*1.0e8) {
 	  //printf ("badly scaled cut - rhs %g els %g -> %g - type %d\n",rhs,smallest,largest,

--- a/src/Osi/OsiPresolve.cpp
+++ b/src/Osi/OsiPresolve.cpp
@@ -271,7 +271,7 @@ OsiPresolve::presolvedModel(OsiSolverInterface &si,
               basicCnt--;
               double down = acts[i] - rlo[i];
               double up = rup[i] - acts[i];
-              if (CoinMin(up, down) < infinity) {
+              if (std::min(up, down) < infinity) {
                 if (down <= up)
                   prob.setRowStatus(i, CoinPrePostsolveMatrix::atLowerBound);
                 else
@@ -376,7 +376,7 @@ OsiPresolve::presolvedModel(OsiSolverInterface &si,
 		lowerValue = 0.0;
 		upperValue = 0.0;
 	      } else if (lowerValue >1.0e-5) {
-		lowerValue = CoinMax(lowerValue,lowerSC);
+		lowerValue = std::max(lowerValue,lowerSC);
 	      }
 	      presolvedModel_->setColBounds(i, lowerValue, upperValue);
 	    }

--- a/src/Osi/OsiRowCutDebugger.cpp
+++ b/src/Osi/OsiRowCutDebugger.cpp
@@ -30,7 +30,7 @@ int OsiRowCutDebugger::validateCuts(const OsiCuts &cs,
   int nbad = 0;
   int i;
   const double epsilon = 1.0e-8;
-  const int nRowCuts = CoinMin(cs.sizeRowCuts(), last);
+  const int nRowCuts = std::min(cs.sizeRowCuts(), last);
 
   for (i = first; i < nRowCuts; i++) {
 
@@ -51,7 +51,7 @@ int OsiRowCutDebugger::validateCuts(const OsiCuts &cs,
     }
     // is it violated
     if (sum > ub + epsilon || sum < lb - epsilon) {
-      double violation = CoinMax(sum - ub, lb - sum);
+      double violation = std::max(sum - ub, lb - sum);
       std::cout << "Cut " << i << " with " << n
                 << " coefficients, cuts off known solution by " << violation
                 << ", lo=" << lb << ", ub=" << ub << std::endl;
@@ -107,7 +107,7 @@ bool OsiRowCutDebugger::invalidCut(const OsiRowCut &rcut) const
   }
   // is it violated
   if (sum > ub + epsilon || sum < lb - epsilon) {
-    double violation = CoinMax(sum - ub, lb - sum);
+    double violation = std::max(sum - ub, lb - sum);
     std::cout << "Cut with " << n
               << " coefficients, cuts off known solutions by " << violation
               << ", lo=" << lb << ", ub=" << ub << std::endl;

--- a/src/Osi/OsiSolverBranch.cpp
+++ b/src/Osi/OsiSolverBranch.cpp
@@ -219,12 +219,12 @@ void OsiSolverBranch::applyBounds(OsiSolverInterface &solver, int way) const
   for (i = start_[base]; i < start_[base + 1]; i++) {
     int iColumn = indices_[i];
     if (iColumn < numberColumns) {
-      double value = CoinMax(bound_[i], columnLower[iColumn]);
+      double value = std::max(bound_[i], columnLower[iColumn]);
       solver.setColLower(iColumn, value);
     } else {
       int iRow = iColumn - numberColumns;
       const double *rowLower = solver.getRowLower();
-      double value = CoinMax(bound_[i], rowLower[iRow]);
+      double value = std::max(bound_[i], rowLower[iRow]);
       solver.setRowLower(iRow, value);
     }
   }
@@ -232,12 +232,12 @@ void OsiSolverBranch::applyBounds(OsiSolverInterface &solver, int way) const
   for (i = start_[base + 1]; i < start_[base + 2]; i++) {
     int iColumn = indices_[i];
     if (iColumn < numberColumns) {
-      double value = CoinMin(bound_[i], columnUpper[iColumn]);
+      double value = std::min(bound_[i], columnUpper[iColumn]);
       solver.setColUpper(iColumn, value);
     } else {
       int iRow = iColumn - numberColumns;
       const double *rowUpper = solver.getRowUpper();
-      double value = CoinMin(bound_[i], rowUpper[iRow]);
+      double value = std::min(bound_[i], rowUpper[iRow]);
       solver.setRowUpper(iRow, value);
     }
   }
@@ -258,7 +258,7 @@ bool OsiSolverBranch::feasibleOneWay(const OsiSolverInterface &solver) const
     for (i = start_[base]; i < start_[base + 1]; i++) {
       int iColumn = indices_[i];
       if (iColumn < numberColumns) {
-        double value = CoinMax(bound_[i], columnLower[iColumn]);
+        double value = std::max(bound_[i], columnLower[iColumn]);
         if (columnSolution[iColumn] < value - primalTolerance) {
           feasible = false;
           break;
@@ -272,7 +272,7 @@ bool OsiSolverBranch::feasibleOneWay(const OsiSolverInterface &solver) const
     for (i = start_[base + 1]; i < start_[base + 2]; i++) {
       int iColumn = indices_[i];
       if (iColumn < numberColumns) {
-        double value = CoinMin(bound_[i], columnUpper[iColumn]);
+        double value = std::min(bound_[i], columnUpper[iColumn]);
         if (columnSolution[iColumn] > value + primalTolerance) {
           feasible = false;
           break;

--- a/src/Osi/OsiSolverInterface.cpp
+++ b/src/Osi/OsiSolverInterface.cpp
@@ -2425,12 +2425,12 @@ OsiSolverInterface::tightPrimalBounds(double * newRowLower,
 	  if (upper>lower) {
 	    double lowerNew = lower;
 	    double upperNew = upper;
-	    maxUp = CoinMax(maxUp,lower);
-	    maxDown = CoinMin(maxDown,upper);
+	    maxUp = std::max(maxUp,lower);
+	    maxDown = std::min(maxDown,upper);
 	    if (!infiniteLower && maxDown > lower + 1.0e-6) 
-	      lowerNew = CoinMax(maxDown-1.0e-6,lower);
+	      lowerNew = std::max(maxDown-1.0e-6,lower);
 	    if (!infiniteUpper && maxUp < upper - 1.0e-6)
-	      upperNew = CoinMin(maxUp+1.0e-6,upper);
+	      upperNew = std::min(maxUp+1.0e-6,upper);
 	    if (lowerNew > upperNew) {
 	      printf("BAD bounds of %g (%g) and %g (%g) on row %d\n",
 		     lowerNew,lower,upperNew,upper,iRow);
@@ -2624,9 +2624,9 @@ OsiSolverInterface::tightPrimalBounds(double * newRowLower,
 		  if (newBound<newUpper[iColumn]-1.0e-7) {
 		    if (isInteger(iColumn)) {
 		      newBound = ceil(newBound);
-		      newBound = CoinMax(newLower[iColumn],newBound);
+		      newBound = std::max(newLower[iColumn],newBound);
 		    } else {
-		      newBound = CoinMax(newLower[iColumn],newBound+1.0e-7);
+		      newBound = std::max(newLower[iColumn],newBound+1.0e-7);
 		    }
 		  }
 		  if (newBound<newUpper[iColumn]-1.0e-7) {
@@ -2665,9 +2665,9 @@ OsiSolverInterface::tightPrimalBounds(double * newRowLower,
 		  if (newBound>newLower[iColumn]+1.0e-7) {
 		    if (isInteger(iColumn)) {
 		      newBound = ceil(newBound);
-		      newBound = CoinMin(newUpper[iColumn],newBound);
+		      newBound = std::min(newUpper[iColumn],newBound);
 		    } else {
-		      newBound = CoinMin(newUpper[iColumn],newBound+1.0e-7);
+		      newBound = std::min(newUpper[iColumn],newBound+1.0e-7);
 		    }
 		  }
 		  if (newBound>newLower[iColumn]+1.0e-7) {
@@ -2736,12 +2736,12 @@ OsiSolverInterface::tightPrimalBounds(double * newRowLower,
               lower -= useTolerance;
             else
               lower = floor(lower + 0.5);
-            lower = CoinMax(columnLower[iColumn], lower);
+            lower = std::max(columnLower[iColumn], lower);
             if (fabs(upper - floor(upper + 0.5)) > 1.0e-9)
               upper += useTolerance;
             else
               upper = floor(upper + 0.5);
-            upper = CoinMin(columnUpper[iColumn], upper);
+            upper = std::min(columnUpper[iColumn], upper);
           }
         }
         newColumnLower[iColumn] = lower;
@@ -2776,7 +2776,7 @@ OsiSolverInterface::tightPrimalBounds(double * newRowLower,
                 numberInteger++;
                 //whichInteger=iColumn;
               }
-              largest = CoinMax(largest, fabs(value));
+              largest = std::max(largest, fabs(value));
               if (value > 0.0) {
                 if (newUpper[iColumn] >= large) {
                   ++infiniteUpper;
@@ -3203,11 +3203,11 @@ void OsiSolverInterface::statistics(double &minimumNegative, double &maximumNega
     for (j = columnStart[i]; j < columnStart[i] + columnLength[i]; j++) {
       double value = elementByColumn[j];
       if (value > 0.0) {
-        minimumPositive = CoinMin(minimumPositive, value);
-        maximumPositive = CoinMax(maximumPositive, value);
+        minimumPositive = std::min(minimumPositive, value);
+        maximumPositive = std::max(maximumPositive, value);
       } else if (value < 0.0) {
-        minimumNegative = CoinMax(minimumNegative, value);
-        maximumNegative = CoinMin(maximumNegative, value);
+        minimumNegative = std::max(minimumNegative, value);
+        maximumNegative = std::min(maximumNegative, value);
       }
     }
   }
@@ -3287,9 +3287,9 @@ void OsiSolverInterface::statistics(double &minimumNegative, double &maximumNega
   printf("\n");
   const double *rowLower = getRowLower();
   const double *rowUpper = getRowUpper();
-  int *number = new int[2 * CoinMax(numberRows, numberColumns)];
-  memset(number, 0, 2 * CoinMax(numberRows, numberColumns) * sizeof(int));
-  int *rowCount = number + CoinMax(numberRows, numberColumns);
+  int *number = new int[2 * std::max(numberRows, numberColumns)];
+  memset(number, 0, 2 * std::max(numberRows, numberColumns) * sizeof(int));
+  int *rowCount = number + std::max(numberRows, numberColumns);
   int numberObjSingletons = 0;
   /* cType
      0 0/inf, 1 0/up, 2 lo/inf, 3 lo/up, 4 free, 5 fix, 6 -inf/0, 7 -inf/up,

--- a/src/OsiCpx/OsiCpxSolverInterface.cpp
+++ b/src/OsiCpx/OsiCpxSolverInterface.cpp
@@ -1557,12 +1557,12 @@ std::vector< double * > OsiCpxSolverInterface::getDualRays(int maxNumRays,
 
   const int numcols = getNumCols();
   const int numrows = getNumRows();
-  int *index = new int[CoinMax(numcols, numrows)];
+  int *index = new int[std::max(numcols, numrows)];
   int i;
-  for (i = CoinMax(numcols, numrows) - 1; i >= 0; --i) {
+  for (i = std::max(numcols, numrows) - 1; i >= 0; --i) {
     index[i] = i;
   }
-  double *obj = new double[CoinMax(numcols, 2 * numrows)];
+  double *obj = new double[std::max(numcols, 2 * numrows)];
   CoinFillN(obj, numcols, 0.0);
   solver.setObjCoeffSet(index, index + numcols, obj);
 

--- a/src/OsiGlpk/OsiGlpkSolverInterface.cpp
+++ b/src/OsiGlpk/OsiGlpkSolverInterface.cpp
@@ -2737,7 +2737,7 @@ void OGSI::loadProblem(const CoinPackedMatrix &matrix,
 
   if (colub_parm == 0 || rowub_parm == 0) {
     if (colub_parm == 0 && rowub_parm == 0) {
-      j = CoinMax(m, n);
+      j = std::max(m, n);
     } else if (colub_parm == 0) {
       j = n;
     } else {

--- a/src/OsiGrb/OsiGrbSolverInterface.cpp
+++ b/src/OsiGrb/OsiGrbSolverInterface.cpp
@@ -1538,12 +1538,12 @@ std::vector< double * > OsiGrbSolverInterface::getDualRays(int maxNumRays,
 
   const int numcols = getNumCols();
   const int numrows = getNumRows();
-  int *index = new int[CoinMax(numcols, numrows)];
+  int *index = new int[std::max(numcols, numrows)];
   int i;
-  for (i = CoinMax(numcols, numrows) - 1; i >= 0; --i) {
+  for (i = std::max(numcols, numrows) - 1; i >= 0; --i) {
     index[i] = i;
   }
-  double *obj = new double[CoinMax(numcols, 2 * numrows)];
+  double *obj = new double[std::max(numcols, 2 * numrows)];
   CoinFillN(obj, numcols, 0.0);
   solver.setObjCoeffSet(index, index + numcols, obj);
 

--- a/src/OsiMsk/OsiMskSolverInterface.cpp
+++ b/src/OsiMsk/OsiMskSolverInterface.cpp
@@ -3776,8 +3776,8 @@ void OsiMskSolverInterface::setRowPrice(const double * rs)
     {    
       redcost[j] = getObjCoefficients()[j]-redcost[j];
     
-      tslx[j] = CoinMax(0.0,redcost[j]);
-      tsux[j] = CoinMax(0.0,-redcost[j]);    
+      tslx[j] = std::max(0.0,redcost[j]);
+      tsux[j] = std::max(0.0,-redcost[j]);    
     }
 
     if( definedSolution( MSK_SOL_BAS ) == true )
@@ -3809,8 +3809,8 @@ void OsiMskSolverInterface::setRowPrice(const double * rs)
         checkMSKerror(err,"MSK_getsucslice","setRowPrice");
 #endif
 
-        tslc[i] = CoinMax(0.0,rowsol_[i]);
-        tsuc[i] = CoinMax(0.0,-rowsol_[i]);
+        tslc[i] = std::max(0.0,rowsol_[i]);
+        tsuc[i] = std::max(0.0,-rowsol_[i]);
       }
 
       err = MSK_getsolution(getMutableLpPtr(),
@@ -3852,8 +3852,8 @@ void OsiMskSolverInterface::setRowPrice(const double * rs)
     {
       for( int i = 0; i < nr; ++i )
       {    
-        tslc[i] = CoinMax(0.0,rowsol_[i]);
-        tsuc[i] = CoinMax(0.0,-rowsol_[i]);
+        tslc[i] = std::max(0.0,rowsol_[i]);
+        tsuc[i] = std::max(0.0,-rowsol_[i]);
         tskc[i] = MSK_SK_UNK;
       }
 

--- a/test/OsiTestSolverInterface.cpp
+++ b/test/OsiTestSolverInterface.cpp
@@ -297,7 +297,7 @@ OsiTestSolverInterface::rowRimResize_(const int newSize)
       double* range = rowrange_;
       double* dual  = rowprice_;
       double* left  = lhs_;
-      maxNumrows_ = CoinMax(1000, (newSize * 5) / 4);
+      maxNumrows_ = std::max(1000, (newSize * 5) / 4);
       rowRimAllocator_();
       const int rownum = getNumRows();
       CoinDisjointCopyN(rub  , rownum, rowupper_);
@@ -329,7 +329,7 @@ OsiTestSolverInterface::colRimResize_(const int newSize)
       double* obj = objcoeffs_;
       double* sol = colsol_;
       double* rc  = rc_;
-      maxNumcols_ = CoinMax(1000, (newSize * 5) / 4);
+      maxNumcols_ = std::max(1000, (newSize * 5) / 4);
       colRimAllocator_();
       const int colnum = getNumCols();
       CoinDisjointCopyN(cub , colnum, colupper_);
@@ -1389,13 +1389,13 @@ OsiTestSolverInterface::applyColCut(const OsiColCut& cc)
    const double* lb_elem = cc.lbs().getElements();
    const int* lb_ind = cc.lbs().getIndices();
    for (i = cc.lbs().getNumElements() - 1; i >= 0; --i) {
-      collower_[lb_ind[i]] = CoinMax(collower_[lb_ind[i]], lb_elem[i]);
+      collower_[lb_ind[i]] = std::max(collower_[lb_ind[i]], lb_elem[i]);
    }
    
    const double* ub_elem = cc.ubs().getElements();
    const int* ub_ind = cc.ubs().getIndices();
    for (i = cc.ubs().getNumElements() - 1; i >= 0; --i) {
-      colupper_[ub_ind[i]] = CoinMin(colupper_[ub_ind[i]], ub_elem[i]);
+      colupper_[ub_ind[i]] = std::min(colupper_[ub_ind[i]], ub_elem[i]);
    }
 }
 


### PR DESCRIPTION
`CoinMax` and `CoinMin` were added more than 20 years ago due to ["for some reason compiler tend to
    handle the `max()`/`min()` function differently"](https://github.com/coin-or/CoinUtils/commit/4eb93a6b7b6c374fcce52b481e7873055030cdea#diff-c42a8bf8cbc38c34a9329260022fec856f0c7b6a563b64059f24bb1051427eb6R205-R212).

This issue should be fixed by now.