### PR TITLE
Fix CPLEX solver interface memory leak

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+04/05/2026
+  - fixed that OsiCpxSolverInterface::getDualRays() did not free some temporarily allocated memory
+
 02/05/2026
   - fixed that OsiGrbSolverInterface::getDualRays() may not have allocated enough memory for an array and did not free some memory
 

--- a/src/OsiCpx/OsiCpxSolverInterface.cpp
+++ b/src/OsiCpx/OsiCpxSolverInterface.cpp
@@ -1598,6 +1598,8 @@ std::vector< double * > OsiCpxSolverInterface::getDualRays(int maxNumRays,
 
   solver.addCols(newcols, cols, clb, cub, obj);
   delete[] index;
+  for (int k = 0; k < newcols; ++k)
+    delete cols[k];
   delete[] cols;
   delete[] clb;
   delete[] cub;


### PR DESCRIPTION
This PR fixes memory leaks in the CPLEX OSI interface.

Problem:
Some code paths in OsiCpxSolverInterface allocated temporary CPLEX-related
resources but did not release them in all execution paths.

Solution:
- Added the missing cleanup of temporary resources
- Kept the changes localized to OsiCpxSolverInterface
- Avoided refactoring unrelated solver-interface logic

Design decision:
The patch is intentionally conservative. The goal is to fix the leaks while
preserving the existing control flow and behavior of the CPLEX backend.

Testing:
- Built OSI with CPLEX support enabled
- Ran the relevant OSI test workflow
- Verified the affected code paths no longer leak the allocated resources

Impact:
This change should not affect other solver interfaces.